### PR TITLE
Fix EMFILE too many open files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## next
 
+- Added `maxConcurrency` option to limit concurrent FS operations, preventing "too many open files" errors (#8)
 - Fixed Node.js warnings such as "Warning: Closing file descriptor # on garbage collection", which is deprecated in Node.js 22 and will result in an error being thrown in the future
 
 ## 0.1.4 (2024-10-30)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ await repo.dispose();
     - `'include'` or `true` (default) - process all packs
     - `'exclude'` or `false` - exclude cruft packs from processing
     - `'only'` - process cruft packs only
+  - `concurrentFsLimit` – number of concurrent file system operations (default: 50)
 
 ### Refs
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ await repo.dispose();
 
 - `gitdir`: string - path to the git repo
 - `options` – optional settings:
+  - `maxConcurrency` – limit the number of file system operations (default: 50)
   - `cruftPacks` – defines how [cruft packs](https://git-scm.com/docs/cruft-packs) are processed:
     - `'include'` or `true` (default) - process all packs
     - `'exclude'` or `false` - exclude cruft packs from processing
     - `'only'` - process cruft packs only
-  - `concurrentFsLimit` – number of concurrent file system operations (default: 50)
 
 ### Refs
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,14 @@ import { createPackedObjectIndex } from './packed-object-index.js';
 import { createFilesMethods } from './files-methods.js';
 import { createCommitMethods } from './commits.js';
 import { createStatMethod } from './stat.js';
+import { promiseAllThreaded } from './utils/threads.js';
 import { GitReaderOptions, NormalizedGitReaderOptions, CruftPackMode } from './types';
 
 export * from './types.js';
 export * from './parse-object.js';
 export { isGitDir, resolveGitDir };
 
-export async function createGitReader(gitdir: string, options?: GitReaderOptions) {
+export async function createGitReader(gitdir: string, options?: Partial<GitReaderOptions>) {
     const startInitTime = Date.now();
     const normalizedOptions = normalizeOptions(options);
     const resolvedGitDir = await resolveGitDir(gitdir);
@@ -39,12 +40,8 @@ export async function createGitReader(gitdir: string, options?: GitReaderOptions
             await Promise.all([looseObjectIndex.dispose(), packedObjectIndex.dispose()]);
         },
         stat: createStatMethod(
-            {
-                gitdir: resolvedGitDir,
-                refIndex,
-                looseObjectIndex,
-                packedObjectIndex
-            },
+            resolvedGitDir,
+            { refIndex, looseObjectIndex, packedObjectIndex },
             normalizedOptions
         ),
 
@@ -52,19 +49,22 @@ export async function createGitReader(gitdir: string, options?: GitReaderOptions
     };
 }
 
-function normalizeOptions(options?: GitReaderOptions): NormalizedGitReaderOptions {
-    if (!options || options.cruftPacks === undefined) {
-        return { cruftPacks: 'include', concurrentFsLimit: 50 };
-    }
+function normalizeOptions(options?: Partial<GitReaderOptions>): NormalizedGitReaderOptions {
+    const { cruftPacks = true, maxConcurrency } = options || {};
+    const maxConcurrencyNormalized = Number.isFinite(maxConcurrency)
+        ? (maxConcurrency as number)
+        : 50;
 
     return {
+        maxConcurrency: maxConcurrencyNormalized,
+        performConcurrent: (queue, action) =>
+            promiseAllThreaded(maxConcurrencyNormalized, queue, action),
         cruftPacks:
-            typeof options.cruftPacks === 'string'
-                ? validateCruftPackMode(options.cruftPacks)
-                : options.cruftPacks // expands true/false aliases
+            typeof cruftPacks === 'string'
+                ? validateCruftPackMode(cruftPacks)
+                : cruftPacks // expands true/false aliases
                 ? 'include'
-                : 'exclude',
-        concurrentFsLimit: options.concurrentFsLimit ?? 50
+                : 'exclude'
     };
 }
 

--- a/src/loose-object-index.ts
+++ b/src/loose-object-index.ts
@@ -17,14 +17,14 @@ type LooseObjectMapEntry = [oid: string, relpath: string];
 
 async function createLooseObjectMap(
     gitdir: string,
-    runConcurrent: NormalizedGitReaderOptions['performConcurrent']
+    { performConcurrent }: NormalizedGitReaderOptions
 ): Promise<LooseObjectMap> {
     const objectsPath = pathJoin(gitdir, 'objects');
     const looseDirs = (await fsPromises.readdir(objectsPath)).filter((p) =>
         /^[0-9a-f]{2}$/.test(p)
     );
 
-    const objectDirs = await runConcurrent(looseDirs, (dir) =>
+    const objectDirs = await performConcurrent(looseDirs, (dir) =>
         fsPromises
             .readdir(pathJoin(objectsPath, dir))
             .then((files) =>
@@ -79,11 +79,8 @@ function parseLooseObject(buffer: Buffer): InternalGitObjectContent {
     };
 }
 
-export async function createLooseObjectIndex(
-    gitdir: string,
-    { performConcurrent }: NormalizedGitReaderOptions
-) {
-    const looseObjectMap = await createLooseObjectMap(gitdir, performConcurrent);
+export async function createLooseObjectIndex(gitdir: string, options: NormalizedGitReaderOptions) {
+    const looseObjectMap = await createLooseObjectMap(gitdir, options);
     const { fanoutTable, binaryNames, names } = indexObjectNames([...looseObjectMap.keys()]);
 
     const getOidFromHash = (hash: Buffer) => {

--- a/src/packed-object-index.ts
+++ b/src/packed-object-index.ts
@@ -20,7 +20,7 @@ const PACKDIR = 'objects/pack';
  */
 export async function createPackedObjectIndex(
     gitdir: string,
-    { cruftPacks }: NormalizedGitReaderOptions
+    { cruftPacks, concurrentFsLimit }: NormalizedGitReaderOptions
 ) {
     function readObjectHeaderByHash(
         hash: Buffer,
@@ -76,7 +76,7 @@ export async function createPackedObjectIndex(
             : !cruftPackFilenames.includes(filename);
     });
 
-    const packFiles = await promiseAllThreaded(20, packFilenames, async (filename) =>
+    const packFiles = await promiseAllThreaded(concurrentFsLimit, packFilenames, async (filename) =>
         readPackFile(gitdir, `${PACKDIR}/${filename}`, readObjectHeaderByHash, readObjectByHash)
     );
 

--- a/src/packed-object-index.ts
+++ b/src/packed-object-index.ts
@@ -2,7 +2,6 @@ import { join as pathJoin } from 'path';
 import { promises as fsPromises } from 'fs';
 import { PackContent, readPackFile } from './packed-pack.js';
 import { objectsStatFromTypes, sumObjectsStat } from './utils/stat.js';
-import { promiseAllThreaded } from './utils/threads.js';
 import {
     InternalGitObjectContent,
     InternalGitObjectHeader,
@@ -20,7 +19,7 @@ const PACKDIR = 'objects/pack';
  */
 export async function createPackedObjectIndex(
     gitdir: string,
-    { cruftPacks, concurrentFsLimit }: NormalizedGitReaderOptions
+    { cruftPacks, performConcurrent }: NormalizedGitReaderOptions
 ) {
     function readObjectHeaderByHash(
         hash: Buffer,
@@ -76,7 +75,7 @@ export async function createPackedObjectIndex(
             : !cruftPackFilenames.includes(filename);
     });
 
-    const packFiles = await promiseAllThreaded(concurrentFsLimit, packFilenames, async (filename) =>
+    const packFiles = await performConcurrent(packFilenames, async (filename) =>
         readPackFile(gitdir, `${PACKDIR}/${filename}`, readObjectHeaderByHash, readObjectByHash)
     );
 

--- a/src/stat.ts
+++ b/src/stat.ts
@@ -2,6 +2,7 @@ import { promises as fsPromises } from 'fs';
 import * as path from 'path';
 import { scanFs } from '@discoveryjs/scan-fs';
 import { sumObjectsStat } from './utils/stat.js';
+import { promiseAllThreaded } from './utils/threads.js';
 import { createRefIndex } from './resolve-ref.js';
 import { createLooseObjectIndex } from './loose-object-index.js';
 import { createPackedObjectIndex } from './packed-object-index.js';
@@ -25,8 +26,8 @@ export function createStatMethod({
             scanFs(gitdir)
         ]);
 
-        const fileStats = await Promise.all(
-            files.map((file) => fsPromises.stat(path.join(gitdir, file.path)))
+        const fileStats = await promiseAllThreaded(20, files, (file) =>
+            fsPromises.stat(path.join(gitdir, file.path))
         );
 
         const objectsTypes = looseObjects.objects.types.map((entry) => ({ ...entry }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,8 +132,14 @@ export interface GitReaderOptions {
      * @default 'include'
      */
     cruftPacks?: CruftPackMode | boolean;
+    /**
+     * Maximum number of concurrent file system operations.
+     * @default 50
+     */
+    concurrentFsLimit?: number;
 }
 
 export interface NormalizedGitReaderOptions {
     cruftPacks: CruftPackMode;
+    concurrentFsLimit: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,15 +131,20 @@ export interface GitReaderOptions {
      *
      * @default 'include'
      */
-    cruftPacks?: CruftPackMode | boolean;
+    cruftPacks: CruftPackMode | boolean;
+
     /**
      * Maximum number of concurrent file system operations.
      * @default 50
      */
-    concurrentFsLimit?: number;
+    maxConcurrency: number;
 }
 
 export interface NormalizedGitReaderOptions {
     cruftPacks: CruftPackMode;
-    concurrentFsLimit: number;
+    maxConcurrency: number;
+    performConcurrent: <T, R>(
+        queue: T[],
+        action: (item: T, itemIdx: number) => Promise<R>
+    ) => Promise<R[]>;
 }

--- a/src/utils/threads.ts
+++ b/src/utils/threads.ts
@@ -1,0 +1,47 @@
+/**
+ * Run async tasks in queue with a maximum number of threads.
+ * Works like Promise.all, but with a maximum number of threads.
+ *   - The order of the results is guaranteed to be the same as the order of the input queue.
+ *   - If any task fails, the whole queue is rejected.
+ *   - If the queue is empty, the result is an empty array.
+ *   - If the queue has only one task, the result is an array with one element.
+ *
+ * @example
+ *   // Before
+ *   const packFiles = await Promise.all(
+ *     packFilenames.map((filename) =>
+ *       readPackFile(gitdir, `${PACKDIR}/${filename}`, readObjectHeaderByHash, readObjectByHash)
+ *     )
+ *   );
+ *
+ *   // After
+ *   const packFiles = await promiseAllThreaded(50, packFilenames, async (filename) =>
+ *     readPackFile(gitdir, `${PACKDIR}/${filename}`, readObjectHeaderByHash, readObjectByHash)
+ *   );
+ */
+export async function promiseAllThreaded<IN, OUT>(
+    maxThreadCount: number,
+    queue: Array<IN>,
+    asyncFn: (task: IN, taskIdx: number) => Promise<OUT>
+): Promise<Array<OUT>> {
+    const result = Array(queue.length);
+    let taskProcessed = 0;
+    let queueSnapshot = [...queue];
+    const thread = async () => {
+        while (taskProcessed < queueSnapshot.length) {
+            const taskIdx = taskProcessed++;
+            const task = queueSnapshot[taskIdx];
+            result[taskIdx] = await asyncFn(task, taskIdx);
+        }
+    };
+
+    await Promise.all(
+        Array.from({ length: Math.min(maxThreadCount, queueSnapshot.length) }, () => thread())
+    ).catch((err) => {
+        // remove all pending tasks
+        queueSnapshot = [];
+        throw err;
+    });
+
+    return result;
+}

--- a/src/utils/threads.ts
+++ b/src/utils/threads.ts
@@ -19,11 +19,11 @@
  *     readPackFile(gitdir, `${PACKDIR}/${filename}`, readObjectHeaderByHash, readObjectByHash)
  *   );
  */
-export async function promiseAllThreaded<IN, OUT>(
+export async function promiseAllThreaded<T, R>(
     maxThreadCount: number,
-    queue: Array<IN>,
-    asyncFn: (task: IN, taskIdx: number) => Promise<OUT>
-): Promise<Array<OUT>> {
+    queue: T[],
+    asyncFn: (task: T, taskIdx: number) => Promise<R>
+): Promise<R[]> {
     const result = Array(queue.length);
     let taskProcessed = 0;
     let queueSnapshot = [...queue];

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,9 +1,38 @@
 import assert from 'assert';
 import { readEncodedOffset, BufferCursor } from '../src/utils/buffer.js';
+import { promiseAllThreaded } from '../src/utils/threads.js';
 
 it('readEncodedOffset', () => {
     const buffer = Buffer.from([142, 254, 254, 254, 254, 254, 254, 127]);
     const cursor = new BufferCursor(buffer);
 
     assert.strictEqual(readEncodedOffset(cursor), Number.MAX_SAFE_INTEGER);
+});
+
+it('promiseAllThreaded', async () => {
+    const maxThreadCount = 2;
+    const queue = [1, 2, 3, 4, 5];
+    const asyncFn = async (task: number) => task * 2;
+
+    const result = await promiseAllThreaded(maxThreadCount, queue, asyncFn);
+
+    assert.deepStrictEqual(result, [2, 4, 6, 8, 10]);
+});
+
+it('promiseAllThreaded with error', async () => {
+    const maxThreadCount = 2;
+    const queue = [1, 2, 3, 4, 5];
+    const asyncFn = async (task: number) => {
+        if (task === 3) {
+            throw new Error('Task failed');
+        }
+        return task * 2;
+    };
+
+    try {
+        await promiseAllThreaded(maxThreadCount, queue, asyncFn);
+        assert.fail('Expected an error');
+    } catch (err) {
+        assert.strictEqual(err.message, 'Task failed');
+    }
 });


### PR DESCRIPTION
This fix helps to avoid `too many open files` error for big repositories:

```
[Error: EMFILE: too many open files, open '/mnt/vss/_work/1/s/repo/.git/refs/remotes/origin/some-branch'] {
  errno: -24,
  code: 'EMFILE',
  syscall: 'open',
  path: '/mnt/vss/_work/1/s/repo/.git/refs/remotes/origin/some-branch'
}
```